### PR TITLE
Add C# console for Figma HTML conversion

### DIFF
--- a/FigmaHtmlGenerator/FigmaHtmlGenerator.csproj
+++ b/FigmaHtmlGenerator/FigmaHtmlGenerator.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/FigmaHtmlGenerator/Generator/ConvertTextFrames.cs
+++ b/FigmaHtmlGenerator/Generator/ConvertTextFrames.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+using System.Linq;
+using FigmaHtmlGenerator.Models;
+using FigmaHtmlGenerator.Utils;
+
+namespace FigmaHtmlGenerator.Generator
+{
+    public class TextFrameData
+    {
+        public TextNode Node { get; set; }
+        public string Tag { get; set; } = "p";
+        public string? CustomClasses { get; set; }
+        public Dictionary<string, string?> CustomAttributes { get; set; } = new();
+        public string Class { get; set; } = string.Empty;
+        public string ElId { get; set; } = string.Empty;
+        public List<StyledTextSegmentData> Segments { get; set; } = new();
+        public StyleData BaseStyle { get; set; } = new();
+        public string X { get; set; } = "0%";
+        public string Y { get; set; } = "0%";
+        public string HorizontalAlignment { get; set; } = "LEFT";
+        public string VerticalAlignment { get; set; } = "TOP";
+        public string Width { get; set; } = "auto";
+        public double Opacity { get; set; }
+        public string Translate { get; set; } = "0%,0%";
+        public double Rotation { get; set; }
+        public List<Effect> Effect { get; set; } = new();
+    }
+
+    public class StyledTextSegmentData
+    {
+        public string Characters { get; set; } = string.Empty;
+        public int Start { get; set; }
+        public int End { get; set; }
+        public string? Hyperlink { get; set; }
+        public StyleData Styles { get; set; } = new();
+        public bool IsBaseStyle { get; set; }
+        public bool IsBold { get; set; }
+        public double? IsOtherWeight { get; set; }
+        public bool IsItalic { get; set; }
+    }
+
+    public static class ConvertTextFrames
+    {
+        static readonly string[] BaseStyleFields = new[]
+        {
+            "font-family","font-size","letter-spacing","color","line-height","mix-blend-mode","text-decoration","text-transform"
+        };
+
+        public static List<TextFrameData> Convert(IEnumerable<TextNode> textFrames, FrameNode artboard)
+        {
+            var frames = new List<TextFrameData>();
+            int idx = 0;
+            foreach (var textFrame in textFrames)
+            {
+                var elId = $"f2h-text-{idx++}";
+                var textSegments = new List<StyledTextSegmentData>();
+
+                var segments = textFrame.Segments;
+                var baseStyle = segments.FirstOrDefault() != null ? StyleProps.Styles(segments.First()) : new StyleData();
+
+                int segIdx = 0;
+                foreach (var seg in segments)
+                {
+                    var styles = StyleProps.Styles(seg);
+                    bool isBase = segIdx == 0 || !BaseStyleFields.Any(f => styles.Object.TryGetValue(f, out var v1) && baseStyle.Object.TryGetValue(f, out var v2) && v1 != v2);
+                    bool isBold = isBase && styles.Object.TryGetValue("font-weight", out var fw) && fw == "700";
+                    double? isOtherWeight = isBase && styles.Object.TryGetValue("font-weight", out var fw2) && fw2 != "400" && fw2 != "700" ? double.Parse(fw2) : null;
+                    bool isItalic = isBase && styles.Object.TryGetValue("font-style", out var fs) && fs == "italic";
+
+                    textSegments.Add(new StyledTextSegmentData
+                    {
+                        Characters = seg.Characters,
+                        Hyperlink = seg.Hyperlink,
+                        Styles = styles,
+                        IsBaseStyle = isBase,
+                        IsBold = isBold,
+                        IsOtherWeight = isOtherWeight,
+                        IsItalic = isItalic
+                    });
+                    segIdx++;
+                }
+
+                double x = 0, y = 0, translateX = 0, translateY = 0;
+                switch (textFrame.TextAlignHorizontal)
+                {
+                    case "CENTER":
+                        x = (textFrame.X / artboard.Width + (textFrame.Width / artboard.Width) / 2) * 100;
+                        translateX = -50;
+                        break;
+                    case "RIGHT":
+                        x = ((textFrame.X + textFrame.Width) / artboard.Width) * 100;
+                        translateX = -100;
+                        break;
+                    default:
+                        x = (textFrame.X / artboard.Width) * 100;
+                        break;
+                }
+
+                switch (textFrame.TextAlignVertical)
+                {
+                    case "CENTER":
+                        y = ((textFrame.Y + textFrame.Height / 2) / artboard.Height) * 100;
+                        translateY = -50;
+                        break;
+                    case "BOTTOM":
+                        y = ((textFrame.Y + textFrame.Height) / artboard.Height) * 100;
+                        translateY = -100;
+                        break;
+                    default:
+                        y = (textFrame.Y / artboard.Height) * 100;
+                        break;
+                }
+
+                frames.Add(new TextFrameData
+                {
+                    Node = textFrame,
+                    Tag = "p",
+                    Class = string.Empty,
+                    ElId = elId,
+                    Segments = textSegments,
+                    BaseStyle = baseStyle,
+                    X = $"{x:F2}%",
+                    Y = $"{y:F2}%",
+                    HorizontalAlignment = textFrame.TextAlignHorizontal,
+                    VerticalAlignment = textFrame.TextAlignVertical,
+                    Width = textFrame.TextAutoResize == "WIDTH_AND_HEIGHT" ? "auto" : $"{textFrame.Width:F2}px",
+                    Opacity = textFrame.Opacity,
+                    Translate = $"{translateX}%, {translateY}%",
+                    Rotation = -textFrame.Rotation,
+                    Effect = textFrame.Effects
+                });
+            }
+            return frames;
+        }
+    }
+}

--- a/FigmaHtmlGenerator/Generator/HtmlFrameGenerator.cs
+++ b/FigmaHtmlGenerator/Generator/HtmlFrameGenerator.cs
@@ -1,0 +1,140 @@
+using System.Text;
+using System.Linq;
+using FigmaHtmlGenerator.Models;
+using FigmaHtmlGenerator.Utils;
+
+namespace FigmaHtmlGenerator.Generator
+{
+    public class FrameContent
+    {
+        public string Html { get; set; } = string.Empty;
+        public string Css { get; set; } = string.Empty;
+    }
+
+    public static class HtmlFrameGenerator
+    {
+        public static FrameContent Generate(FrameNode node, string filename, WidthRangeInfo widthRange, string alt, ExportConfig config)
+        {
+            var inlineStyle = new StringBuilder();
+            var content = new FrameContent();
+
+            double width = node.Width;
+            double height = node.Height;
+            double aspectRatio = width / height;
+            var index = widthRange.Widths.IndexOf(width);
+            var range = widthRange.Ranges[index];
+
+            string frameClass = "f2h-frame";
+            string id = $"f2h-frame-{width}";
+            string format = config.Format.ToString().ToLowerInvariant();
+
+            content.Css += $"\t#{id} {{ position: relative; overflow: hidden; display: none; }}\n";
+
+            var textData = ConvertTextFrames.Convert(node.TextNodes, node);
+
+            if (!config.Fluid)
+                inlineStyle.Append($"width: {width}px;");
+
+            content.Html += $"\n\t<!-- Frame: {filename} -->\n";
+            content.Html += $"\t<div {Stringify.Attrs(new Dictionary<string, string?>
+            {
+                ["id"] = id,
+                ["class"] = $"{frameClass} frame artboard",
+                ["data-aspect-ratio"] = aspectRatio.ToString("F3"),
+                ["data-min-width"] = range.Min.ToString(),
+                ["data-max-width"] = range.Max?.ToString(),
+                ["style"] = inlineStyle.ToString()
+            })}>";
+
+            content.Html += $"\n\t\t<div {Stringify.Attrs(new Dictionary<string, string?>
+            {
+                ["class"] = "spacer",
+                ["style"] = Stringify.Styles(new Dictionary<string, string?>
+                {
+                    ["padding"] = "0 0 0 0",
+                    ["min-width"] = width > 0 ? $"{width}px" : "auto",
+                    ["max-width"] = range.Max.HasValue ? $"{range.Max.Value}px" : "none"
+                })
+            })}></div>";
+
+            content.Html += $"\n\t\t<picture>\n\t\t\t<img {Stringify.Attrs(new Dictionary<string, string?>
+            {
+                ["id"] = "img-" + id,
+                ["class"] = "f2h-img",
+                ["alt"] = alt,
+                ["data-src"] = filename + "." + format,
+                ["src"] = "data:image/gif;base64,R0lGODlhCgAKAIAAAB8fHwAAACH5BAEAAAAALAAAAAAKAAoAAAIIhI+py+0PYysAOw==",
+                ["loading"] = "lazy",
+                ["draggable"] = "false",
+                ["decoding"] = "async",
+                ["width"] = width.ToString("F2"),
+                ["height"] = !config.Fluid ? height.ToString("F2") : null
+            })}/>\n\t\t</picture>\n";
+
+            if (textData.Any())
+            {
+                var baseStyles = textData.Select(t => t.BaseStyle).ToList();
+                var pStyle = baseStyles
+                    .GroupBy(s => s.String)
+                    .OrderByDescending(g => g.Count())
+                    .FirstOrDefault()?.FirstOrDefault();
+                if (config.StyleTextSegments && pStyle != null && !string.IsNullOrEmpty(pStyle.String))
+                {
+                    content.Css += $"\n\t#{id} {pStyle.Tag} {{ {pStyle.String} }}";
+                }
+
+                foreach (var text in textData)
+                {
+                    var style = new Dictionary<string, string?>
+                    {
+                        ["top"] = text.Y,
+                        ["left"] = text.X,
+                        ["opacity"] = text.Opacity.ToString(),
+                        ["width"] = text.Width
+                    };
+
+                    style["transform"] = $"translate({text.Translate}) rotate({text.Rotation}deg)";
+                    style["transform-origin"] = "left top";
+                    style["text-align"] = text.HorizontalAlignment.ToLowerInvariant();
+
+                    var attrs = Stringify.Attrs(new Dictionary<string, string?>
+                    {
+                        ["class"] = "f2h-text",
+                        ["style"] = Stringify.Styles(style)
+                    });
+
+                    content.Html += $"<div {attrs}>";
+
+                    var elements = new List<(string Tag, List<StyledTextSegmentData> Segments)>();
+                    for (int i = 0; i < text.Segments.Count; i++)
+                    {
+                        var seg = text.Segments[i];
+                        var prevEndsNew = i > 0 && text.Segments[i - 1].Characters.EndsWith("\n");
+                        var thisEndsNew = seg.Characters.EndsWith("\n");
+                        var thisIncludesNew = seg.Characters.Contains("\n");
+                        bool notNewEl = i > 0 && !prevEndsNew && !(thisIncludesNew && !thisEndsNew);
+                        if (notNewEl)
+                            elements.Last().Segments.Add(seg);
+                        else
+                            elements.Add((text.Tag, new List<StyledTextSegmentData> { seg }));
+                    }
+
+                    foreach (var element in elements)
+                    {
+                        content.Html += $"\n\t\t\t<{element.Tag}>";
+                        foreach (var seg in element.Segments)
+                        {
+                            content.Html += SpanRenderer.Render(text.Node, seg, config.StyleTextSegments);
+                        }
+                        content.Html += $"</{element.Tag}>\n";
+                    }
+
+                    content.Html += "\t\t</div>\n";
+                }
+            }
+
+            content.Html += "\t</div>\n";
+            return content;
+        }
+    }
+}

--- a/FigmaHtmlGenerator/Generator/HtmlWrapper.cs
+++ b/FigmaHtmlGenerator/Generator/HtmlWrapper.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FigmaHtmlGenerator.Models;
+using FigmaHtmlGenerator.Utils;
+
+namespace FigmaHtmlGenerator.Generator
+{
+    public static class HtmlWrapper
+    {
+        public static string Generate(IEnumerable<FrameNode> assets, ExportConfig config, object? variables)
+        {
+            var containerId = $"{config.Filename}-box";
+            var frameCss = new StringBuilder();
+            var frameHtml = new StringBuilder();
+
+            var widthRange = WidthRange.Calculate(assets);
+
+            foreach (var asset in assets)
+            {
+                var frame = HtmlFrameGenerator.Generate(asset, config.Filename, widthRange, config.AltText, config);
+                frameCss.Append("\n\n" + frame.Css);
+                frameHtml.Append("\n\n" + frame.Html);
+            }
+
+            var css = new StringBuilder();
+            css.AppendLine($"#{containerId} {{ max-width: {(config.MaxWidth.HasValue ? config.MaxWidth + "px" : "none")}; margin: {(config.Centered ? "0 auto" : "0")}; }}");
+            css.AppendLine($"#{containerId} .f2h-frame {{ margin: {(config.Centered ? "0 auto" : "0")}; }}");
+            css.Append(frameCss.ToString());
+
+            var html = new StringBuilder();
+            html.AppendLine($"<style type='text/css'>{css}</style>");
+            html.AppendLine($"<div id=\"{containerId}\" class=\"figma2html\">{frameHtml}</div>");
+
+            return html.ToString();
+        }
+    }
+}

--- a/FigmaHtmlGenerator/Generator/SpanRenderer.cs
+++ b/FigmaHtmlGenerator/Generator/SpanRenderer.cs
@@ -1,0 +1,41 @@
+using FigmaHtmlGenerator.Models;
+using System.Text;
+
+namespace FigmaHtmlGenerator.Generator
+{
+    public static class SpanRenderer
+    {
+        public static string Render(TextNode parent, StyledTextSegmentData segment, bool styleTextSegments)
+        {
+            var sb = new StringBuilder();
+            var characters = segment.Characters;
+
+            if (!string.IsNullOrEmpty(segment.Hyperlink))
+                sb.Append($"<a href=\"{segment.Hyperlink}\" target=\"_blank\">");
+
+            if (!segment.IsBaseStyle && styleTextSegments)
+                sb.Append($"<span style=\"{segment.Styles.String}\">");
+            if (segment.IsOtherWeight.HasValue && styleTextSegments)
+                sb.Append($"<span style=\"font-weight: {segment.IsOtherWeight.Value}\">");
+            if (segment.IsItalic)
+                sb.Append("<i>");
+            if (segment.IsBold)
+                sb.Append("<b>");
+
+            sb.Append(characters);
+
+            if (segment.IsBold)
+                sb.Append("</b>");
+            if (segment.IsItalic)
+                sb.Append("</i>");
+            if (segment.IsOtherWeight.HasValue && styleTextSegments)
+                sb.Append("</span>");
+            if (!segment.IsBaseStyle && styleTextSegments)
+                sb.Append("</span>");
+            if (!string.IsNullOrEmpty(segment.Hyperlink))
+                sb.Append("</a>");
+
+            return sb.ToString();
+        }
+    }
+}

--- a/FigmaHtmlGenerator/Generator/StyleProps.cs
+++ b/FigmaHtmlGenerator/Generator/StyleProps.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+using FigmaHtmlGenerator.Models;
+
+namespace FigmaHtmlGenerator.Generator
+{
+    public class StyleData
+    {
+        public Dictionary<string, string?> Object { get; set; } = new();
+        public string String => string.Join(" ", Object.Where(o => !string.IsNullOrEmpty(o.Value)).Select(o => $"{o.Key}: {o.Value};"));
+    }
+
+    public static class StyleProps
+    {
+        public static StyleData Styles(StyledTextSegment segment)
+        {
+            if (segment == null) return new StyleData();
+
+            string? color = null;
+            string? blend = null;
+            if (segment.Fills.Any())
+            {
+                var fill = segment.Fills.First();
+                color = fill.Color.ToCssRgba();
+                blend = fill.BlendMode.ToLowerInvariant();
+            }
+
+            var obj = new Dictionary<string, string?>
+            {
+                ["font-family"] = segment.FontName.Family,
+                ["font-style"] = segment.FontName.Style.Contains("Italic") ? "italic" : "normal",
+                ["font-weight"] = segment.FontWeight.ToString(),
+                ["font-size"] = segment.FontSize + "px",
+                ["text-decoration"] = segment.TextDecoration.ToLowerInvariant(),
+                ["text-transform"] = segment.TextCase == "ORIGINAL" ? "none" : segment.TextCase.ToLowerInvariant(),
+                ["line-height"] = segment.LineHeight.Unit == "AUTO" ? "normal" : segment.LineHeight.Unit == "PERCENT" && segment.LineHeight.Value > 0 ? (segment.LineHeight.Value/100).ToString() : segment.LineHeight.Value + "px",
+                ["letter-spacing"] = segment.LetterSpacing.Unit == "PERCENT" && segment.LetterSpacing.Value > 0 ? (segment.LetterSpacing.Value/100).ToString() : segment.LetterSpacing.Value + "px",
+                ["color"] = color,
+                ["mix-blend-mode"] = blend
+            };
+
+            return new StyleData { Object = obj };
+        }
+    }
+}

--- a/FigmaHtmlGenerator/Generator/TextEffectCss.cs
+++ b/FigmaHtmlGenerator/Generator/TextEffectCss.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Text;
+using FigmaHtmlGenerator.Models;
+
+namespace FigmaHtmlGenerator.Generator
+{
+    public static class TextEffectCss
+    {
+        public static string Build(IEnumerable<Effect> effects)
+        {
+            var sb = new StringBuilder();
+            var shadows = new List<string>();
+            foreach (var effect in effects)
+            {
+                if (effect.Type == EffectType.DropShadow && effect.Visible)
+                {
+                    var color = effect.Color.ToCssRgba();
+                    shadows.Add($"{effect.Offset.X}px {effect.Offset.Y}px {effect.Radius}px {color}");
+                }
+            }
+            if (shadows.Count > 0)
+            {
+                sb.Append("text-shadow: ");
+                sb.Append(string.Join(", ", shadows));
+                sb.Append("; ");
+            }
+            foreach (var effect in effects)
+            {
+                if (effect.Type == EffectType.LayerBlur && effect.Visible)
+                {
+                    sb.Append($"-webkit-filter: blur({effect.Radius}px); filter: blur({effect.Radius}px);");
+                }
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/FigmaHtmlGenerator/Generator/WidthRange.cs
+++ b/FigmaHtmlGenerator/Generator/WidthRange.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Linq;
+using FigmaHtmlGenerator.Models;
+
+namespace FigmaHtmlGenerator.Generator
+{
+    public class WidthRangeInfo
+    {
+        public List<double> Widths { get; set; } = new();
+        public List<(double Min, double Max?)> Ranges { get; set; } = new();
+    }
+
+    public static class WidthRange
+    {
+        public static WidthRangeInfo Calculate(IEnumerable<FrameNode> assets)
+        {
+            var info = new WidthRangeInfo();
+            foreach (var asset in assets)
+            {
+                var width = asset.Width;
+                info.Widths.Add(width);
+            }
+            info.Widths.Sort();
+            for (int i = 0; i < info.Widths.Count; i++)
+            {
+                double width = info.Widths[i];
+                if (i == 0)
+                    info.Ranges.Add((0, info.Widths.Count > 1 ? info.Widths[1] - 1 : (double?)null));
+                else if (i < info.Widths.Count - 1)
+                    info.Ranges.Add((info.Widths[i], info.Widths[i + 1] - 1));
+                else
+                    info.Ranges.Add((width, null));
+            }
+            return info;
+        }
+    }
+}

--- a/FigmaHtmlGenerator/Models/Effect.cs
+++ b/FigmaHtmlGenerator/Models/Effect.cs
@@ -1,0 +1,11 @@
+namespace FigmaHtmlGenerator.Models
+{
+    public class Effect
+    {
+        public EffectType Type { get; set; }
+        public bool Visible { get; set; } = true;
+        public Offset Offset { get; set; } = new(0,0);
+        public double Radius { get; set; }
+        public Color Color { get; set; } = new(0,0,0,1);
+    }
+}

--- a/FigmaHtmlGenerator/Models/Enums.cs
+++ b/FigmaHtmlGenerator/Models/Enums.cs
@@ -1,0 +1,15 @@
+namespace FigmaHtmlGenerator.Models
+{
+    public enum ImageFormat
+    {
+        Png,
+        Jpg,
+        Svg
+    }
+
+    public enum EffectType
+    {
+        DropShadow,
+        LayerBlur
+    }
+}

--- a/FigmaHtmlGenerator/Models/ExampleData.cs
+++ b/FigmaHtmlGenerator/Models/ExampleData.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace FigmaHtmlGenerator.Models
+{
+    public static class ExampleData
+    {
+        public static FrameNode CreateSampleFrame()
+        {
+            var textSegment = new StyledTextSegment
+            {
+                Characters = "Hello World",
+                FontSize = 24,
+                FontName = new FontName("Arial", "Regular"),
+                Fills = new List<Paint> { new Paint { Color = new Color(0,0,0,1), Opacity = 1.0 } }
+            };
+
+            var textNode = new TextNode
+            {
+                X = 0,
+                Y = 0,
+                Width = 200,
+                Height = 30,
+                Segments = new List<StyledTextSegment> { textSegment }
+            };
+
+            var frame = new FrameNode
+            {
+                Name = "#600px",
+                Width = 600,
+                Height = 400,
+                TextNodes = new List<TextNode> { textNode }
+            };
+
+            return frame;
+        }
+    }
+}

--- a/FigmaHtmlGenerator/Models/ExportConfig.cs
+++ b/FigmaHtmlGenerator/Models/ExportConfig.cs
@@ -1,0 +1,13 @@
+namespace FigmaHtmlGenerator.Models
+{
+    public class ExportConfig
+    {
+        public string Filename { get; set; } = "export";
+        public ImageFormat Format { get; set; } = ImageFormat.Png;
+        public bool Fluid { get; set; } = true;
+        public string AltText { get; set; } = string.Empty;
+        public bool StyleTextSegments { get; set; } = true;
+        public bool Centered { get; set; } = false;
+        public int? MaxWidth { get; set; }
+    }
+}

--- a/FigmaHtmlGenerator/Models/FrameNode.cs
+++ b/FigmaHtmlGenerator/Models/FrameNode.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace FigmaHtmlGenerator.Models
+{
+    public class FrameNode
+    {
+        public string Name { get; set; } = string.Empty;
+        public double Width { get; set; }
+        public double Height { get; set; }
+        public List<TextNode> TextNodes { get; set; } = new();
+    }
+}

--- a/FigmaHtmlGenerator/Models/Geometry.cs
+++ b/FigmaHtmlGenerator/Models/Geometry.cs
@@ -1,0 +1,9 @@
+namespace FigmaHtmlGenerator.Models
+{
+    public record Offset(double X, double Y);
+
+    public record Color(double R, double G, double B, double A = 1.0)
+    {
+        public string ToCssRgba() => $"rgba({R * 255:F0}, {G * 255:F0}, {B * 255:F0}, {A})";
+    }
+}

--- a/FigmaHtmlGenerator/Models/StyledTextSegment.cs
+++ b/FigmaHtmlGenerator/Models/StyledTextSegment.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace FigmaHtmlGenerator.Models
+{
+    public class StyledTextSegment
+    {
+        public string Characters { get; set; } = string.Empty;
+        public FontName FontName { get; set; } = new("Arial", "Regular");
+        public int FontWeight { get; set; } = 400;
+        public double FontSize { get; set; }
+        public string TextDecoration { get; set; } = "none";
+        public string TextCase { get; set; } = "ORIGINAL";
+        public LineHeight LineHeight { get; set; } = new();
+        public LetterSpacing LetterSpacing { get; set; } = new();
+        public List<Paint> Fills { get; set; } = new();
+        public string? Hyperlink { get; set; }
+    }
+
+    public class Paint
+    {
+        public Color Color { get; set; } = new(0,0,0,1);
+        public double Opacity { get; set; } = 1.0;
+        public string BlendMode { get; set; } = "NORMAL";
+    }
+}

--- a/FigmaHtmlGenerator/Models/TextNode.cs
+++ b/FigmaHtmlGenerator/Models/TextNode.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace FigmaHtmlGenerator.Models
+{
+    public class TextNode
+    {
+        public string Name { get; set; } = string.Empty;
+        public double X { get; set; }
+        public double Y { get; set; }
+        public double Width { get; set; }
+        public double Height { get; set; }
+        public double Opacity { get; set; } = 1.0;
+        public double Rotation { get; set; }
+        public string TextAlignHorizontal { get; set; } = "LEFT";
+        public string TextAlignVertical { get; set; } = "TOP";
+        public string TextAutoResize { get; set; } = "NONE"; // WIDTH_AND_HEIGHT etc
+        public List<StyledTextSegment> Segments { get; set; } = new();
+        public List<Effect> Effects { get; set; } = new();
+    }
+}

--- a/FigmaHtmlGenerator/Models/Typography.cs
+++ b/FigmaHtmlGenerator/Models/Typography.cs
@@ -1,0 +1,16 @@
+namespace FigmaHtmlGenerator.Models
+{
+    public record FontName(string Family, string Style);
+
+    public class LineHeight
+    {
+        public string Unit { get; set; } = "AUTO"; // AUTO, PIXELS, PERCENT
+        public double Value { get; set; }
+    }
+
+    public class LetterSpacing
+    {
+        public string Unit { get; set; } = "PIXELS"; // PIXELS or PERCENT
+        public double Value { get; set; }
+    }
+}

--- a/FigmaHtmlGenerator/Program.cs
+++ b/FigmaHtmlGenerator/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using FigmaHtmlGenerator.Generator;
+using FigmaHtmlGenerator.Models;
+
+namespace FigmaHtmlGenerator
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            // Example usage with placeholder frame data
+            var frame = ExampleData.CreateSampleFrame();
+            var config = new ExportConfig
+            {
+                Filename = "example",
+                Format = ImageFormat.Png,
+                Fluid = true,
+                AltText = "Sample image",
+                StyleTextSegments = true
+            };
+
+            string html = HtmlWrapper.Generate(new[] { frame }, config, null);
+            Console.WriteLine(html);
+        }
+    }
+}

--- a/FigmaHtmlGenerator/Utils/RoundHelper.cs
+++ b/FigmaHtmlGenerator/Utils/RoundHelper.cs
@@ -1,0 +1,10 @@
+namespace FigmaHtmlGenerator.Utils
+{
+    public static class RoundHelper
+    {
+        public static double RoundTo(double number, int precision)
+        {
+            return Math.Round(number, precision);
+        }
+    }
+}

--- a/FigmaHtmlGenerator/Utils/Slugify.cs
+++ b/FigmaHtmlGenerator/Utils/Slugify.cs
@@ -1,0 +1,14 @@
+using System.Text.RegularExpressions;
+
+namespace FigmaHtmlGenerator.Utils
+{
+    public static class Slugify
+    {
+        public static string Slug(string str)
+        {
+            var slug = Regex.Replace(str, "[^a-zA-Z0-9\s]", "");
+            slug = Regex.Replace(slug, "\s+", "-");
+            return slug.ToLowerInvariant();
+        }
+    }
+}

--- a/FigmaHtmlGenerator/Utils/Stringify.cs
+++ b/FigmaHtmlGenerator/Utils/Stringify.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FigmaHtmlGenerator.Utils
+{
+    public static class Stringify
+    {
+        public static string Attrs(Dictionary<string, string?> attributes)
+        {
+            return string.Join(" ", attributes
+                .Where(kv => !string.IsNullOrEmpty(kv.Value))
+                .Select(kv => $"{kv.Key}=\"{kv.Value}\""));
+        }
+
+        public static string Styles(Dictionary<string, string?> styles)
+        {
+            return string.Join(" ", styles
+                .Where(kv => !string.IsNullOrEmpty(kv.Value))
+                .Select(kv => $"{kv.Key}: {kv.Value};"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `FigmaHtmlGenerator` console app
- implement helpers and models for Figma frame and text data
- port core conversion logic from TypeScript to C#

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6852ac2b68c0832897fa11cf98716114